### PR TITLE
fix a CRITICAL BUG when ig.LangLabel#init receives a string

### DIFF
--- a/prestart.js
+++ b/prestart.js
@@ -32,8 +32,14 @@ const APPREHEND = {
 
 ig.LangLabel.inject({
 	init(data) {
-		if(data)
-			data.en_US = generateDumpsterFire(data.en_US.toLowerCase());
+		if(data) {
+			if(data.constructor === String) {
+				if(ig.currentLang === 'en_US')
+					data = generateDumpsterFire(data);
+			} else {
+				data.en_US = generateDumpsterFire(data.en_US);
+			}
+		}
 		this.parent(data);
 	}
 });
@@ -42,6 +48,8 @@ ig.LangLabel.inject({
 // So I'm taking the lazy solution of just checking if there's a null byte at position zero.
 function generateDumpsterFire(line) {
 	if(line && line.constructor === String && line[0] !== '\0') {
+		line = line.toLowerCase();
+
 		// Press \\i[key-up]\\i[key-left]\\i[key-down]\\i[key-right] to move around
 		// You are at \\c[3]level \\v[player.level]\\c[0]!
 		let stack = [];


### PR DESCRIPTION
More context here: <https://discord.com/channels/382339402338402315/382339402338402317/876494059634561115>
Save that causes the crash: <https://cdn.discordapp.com/attachments/382339402338402317/876496292019314728/save.txt>
I believe that the exact thing that triggered the crash was receiving a trophy and notification popping up for that event.