### PR TITLE
Add ccmod.json

### DIFF
--- a/ccmod.json
+++ b/ccmod.json
@@ -1,0 +1,10 @@
+{
+	"id": "uwuifier",
+	"version": "1.0.2",
+	"title": "uwuifier",
+	"description": "Dynamically uwuifies text.",
+	"repository": "https://github.com/WatDuhHekBro/cc-uwuifier",
+    "tags": ["fun"],
+    "authors": ["WatDuhHekBro", "dmitmel"],
+	"prestart": "prestart.js"
+}


### PR DESCRIPTION
Hi!
I want to add your mod to a centralized mod repository called CCModDB (your mod was once there).
It will allow the upcoming in-game [mod manager](https://github.com/CCDirectLink/CCModManager) to see your mod and make it one-click-installable with all the dependencies.
It requires `ccmod.json` to be present.
Please create a new release after merging (with a .ccmod or not).